### PR TITLE
Release/snowplow ecommerce/0.5.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+snowplow-ecommerce 0.5.1 (2023-07-12)
+---------------------------------------
+## Summary
+This version fixes a bug that may occur when duplicate events in Redshift/Postgres have different collector timestamps.
+
+## Fixes
+- Fix bug relating to duplicate filtering
+
+## Upgrading
+Bump the snowplow-ecommerce version in your `packages.yml` file.
+
 snowplow-ecommerce 0.5.0 (2023-06-27)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 name: 'snowplow_ecommerce'
 
-version: '0.5.0'
+version: '0.5.1'
 config-version: 2
 
 require-dbt-version: [">=1.4.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_ecommerce_integration_tests'
-version: '0.5.0'
+version: '0.5.1'
 config-version: 2
 
 profile: 'integration_tests'

--- a/models/base/scratch/default/snowplow_ecommerce_base_events_this_run.sql
+++ b/models/base/scratch/default/snowplow_ecommerce_base_events_this_run.sql
@@ -334,4 +334,4 @@ from events_this_run ev
     left join {{ var('snowplow__context_screen') }} sv on ev.event_id = sv.mob_sc_view__id and ev.collector_tstamp = sv.mob_sc_view__tstamp
 {%- endif %}
 where
-    ev.event_id_dedupe_index = ev.event_id_dedupe_count
+    ev.event_id_dedupe_index = 1


### PR DESCRIPTION
## Description & motivation
Yes I shouldn't do this in a single PR, but who has the time.

Currently we filter contexts/sde tables on their dedupe index to =1 (in the `get_sde_or_context` macro), based on the earlier collector timestamp. This should be the same approach we take in the base events model but we don’t, this could lead to failing joins in case of dupes with different timestamps. This PR fixes that issue by filtering the main table to also have the index = 1.

I will add the docs to bump the version once it is released.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)


## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have updated the CHANGELOG.md 
