### PR TITLE
Add sort, dist and cluster_by config to base_sessions_lifecycle manifest (close #34)

### DIFF
--- a/models/base/manifest/bigquery/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/bigquery/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
@@ -1,16 +1,23 @@
 {{
   config(
-    materialized="incremental",
+    materialized='incremental',
     unique_key='session_id',
     upsert_date_key='start_tstamp',
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    sort='start_tstamp',
+    dist='session_id',
     partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
     }, databricks_val='start_tstamp_date'),
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["session_id"], snowflake_val=["to_date(start_tstamp)"]),
     full_refresh=snowplow_ecommerce.allow_refresh(),
     tags=["manifest"],
-    snowplow_optimize=true
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    tblproperties={
+      'delta.autoOptimize.optimizeWrite' : 'true',
+      'delta.autoOptimize.autoCompact' : 'true'
+    },
+    snowplow_optimize = true
   )
 }}
 

--- a/models/base/manifest/databricks/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/databricks/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
@@ -1,16 +1,23 @@
 {{
   config(
-    materialized="incremental",
+    materialized='incremental',
     unique_key='session_id',
     upsert_date_key='start_tstamp',
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    sort='start_tstamp',
+    dist='session_id',
     partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
     }, databricks_val='start_tstamp_date'),
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["session_id"], snowflake_val=["to_date(start_tstamp)"]),
     full_refresh=snowplow_ecommerce.allow_refresh(),
     tags=["manifest"],
-    snowplow_optimize=true
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    tblproperties={
+      'delta.autoOptimize.optimizeWrite' : 'true',
+      'delta.autoOptimize.autoCompact' : 'true'
+    },
+    snowplow_optimize = true
   )
 }}
 

--- a/models/base/manifest/default/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/default/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
@@ -1,16 +1,23 @@
 {{
   config(
-    materialized="incremental",
+    materialized='incremental',
     unique_key='session_id',
     upsert_date_key='start_tstamp',
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    sort='start_tstamp',
+    dist='session_id',
     partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
     }, databricks_val='start_tstamp_date'),
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["session_id"], snowflake_val=["to_date(start_tstamp)"]),
     full_refresh=snowplow_ecommerce.allow_refresh(),
     tags=["manifest"],
-    snowplow_optimize=true
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    tblproperties={
+      'delta.autoOptimize.optimizeWrite' : 'true',
+      'delta.autoOptimize.autoCompact' : 'true'
+    },
+    snowplow_optimize = true
   )
 }}
 

--- a/models/base/manifest/snowflake/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/snowflake/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
@@ -1,16 +1,23 @@
 {{
   config(
-    materialized="incremental",
+    materialized='incremental',
     unique_key='session_id',
     upsert_date_key='start_tstamp',
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    sort='start_tstamp',
+    dist='session_id',
     partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
     }, databricks_val='start_tstamp_date'),
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["session_id"], snowflake_val=["to_date(start_tstamp)"]),
     full_refresh=snowplow_ecommerce.allow_refresh(),
     tags=["manifest"],
-    snowplow_optimize=true
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    tblproperties={
+      'delta.autoOptimize.optimizeWrite' : 'true',
+      'delta.autoOptimize.autoCompact' : 'true'
+    },
+    snowplow_optimize = true
   )
 }}
 

--- a/models/base/manifest/snowplow_ecommerce_incremental_manifest.sql
+++ b/models/base/manifest/snowplow_ecommerce_incremental_manifest.sql
@@ -2,7 +2,11 @@
   config(
     materialized='incremental',
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
-    full_refresh=snowplow_ecommerce.allow_refresh()
+    full_refresh=snowplow_ecommerce.allow_refresh(),
+    tblproperties={
+      'delta.autoOptimize.optimizeWrite' : 'true',
+      'delta.autoOptimize.autoCompact' : 'true'
+    }
   )
 }}
 


### PR DESCRIPTION
Issue #34 

This PR adds configuration properties to the `snowplow_ecommerce_incremental_manifest` and `snowplow_ecommerce_base_sessions_lifecycle_manifest` that were missing, in particular:

* sort
* dist
* cluster_by
* tblproperties

The properties are now the same as set by the `dbt-snowplow-web` package.