### PR TITLE
Release/snowplow ecommerce/0.5.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+snowplow-ecommerce 0.5.2 (2023-09-04)
+---------------------------------------
+## Summary
+This version adds configuration properties to the `snowplow_ecommerce_incremental_manifest` and `snowplow_ecommerce_base_sessions_lifecycle_manifest` that were missing (in particular `sort`, `dist`, `cluster_by`, `tblproperties`).
+
+## Fixes
+- Add sort, dist and cluster_by config to base_sessions_lifecycle manifest (close #34)
+
+## Upgrading
+Bump the snowplow-ecommerce version in your `packages.yml` file.
+
 snowplow-ecommerce 0.5.1 (2023-07-12)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 name: 'snowplow_ecommerce'
 
-version: '0.5.1'
+version: '0.5.2'
 config-version: 2
 
 require-dbt-version: [">=1.4.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_ecommerce_integration_tests'
-version: '0.5.1'
+version: '0.5.2'
 config-version: 2
 
 profile: 'integration_tests'

--- a/models/base/manifest/bigquery/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/bigquery/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
@@ -1,16 +1,23 @@
 {{
   config(
-    materialized="incremental",
+    materialized='incremental',
     unique_key='session_id',
     upsert_date_key='start_tstamp',
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    sort='start_tstamp',
+    dist='session_id',
     partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
     }, databricks_val='start_tstamp_date'),
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["session_id"], snowflake_val=["to_date(start_tstamp)"]),
     full_refresh=snowplow_ecommerce.allow_refresh(),
     tags=["manifest"],
-    snowplow_optimize=true
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    tblproperties={
+      'delta.autoOptimize.optimizeWrite' : 'true',
+      'delta.autoOptimize.autoCompact' : 'true'
+    },
+    snowplow_optimize = true
   )
 }}
 

--- a/models/base/manifest/databricks/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/databricks/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
@@ -1,16 +1,23 @@
 {{
   config(
-    materialized="incremental",
+    materialized='incremental',
     unique_key='session_id',
     upsert_date_key='start_tstamp',
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    sort='start_tstamp',
+    dist='session_id',
     partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
     }, databricks_val='start_tstamp_date'),
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["session_id"], snowflake_val=["to_date(start_tstamp)"]),
     full_refresh=snowplow_ecommerce.allow_refresh(),
     tags=["manifest"],
-    snowplow_optimize=true
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    tblproperties={
+      'delta.autoOptimize.optimizeWrite' : 'true',
+      'delta.autoOptimize.autoCompact' : 'true'
+    },
+    snowplow_optimize = true
   )
 }}
 

--- a/models/base/manifest/default/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/default/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
@@ -1,16 +1,23 @@
 {{
   config(
-    materialized="incremental",
+    materialized='incremental',
     unique_key='session_id',
     upsert_date_key='start_tstamp',
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    sort='start_tstamp',
+    dist='session_id',
     partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
     }, databricks_val='start_tstamp_date'),
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["session_id"], snowflake_val=["to_date(start_tstamp)"]),
     full_refresh=snowplow_ecommerce.allow_refresh(),
     tags=["manifest"],
-    snowplow_optimize=true
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    tblproperties={
+      'delta.autoOptimize.optimizeWrite' : 'true',
+      'delta.autoOptimize.autoCompact' : 'true'
+    },
+    snowplow_optimize = true
   )
 }}
 

--- a/models/base/manifest/snowflake/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/snowflake/snowplow_ecommerce_base_sessions_lifecycle_manifest.sql
@@ -1,16 +1,23 @@
 {{
   config(
-    materialized="incremental",
+    materialized='incremental',
     unique_key='session_id',
     upsert_date_key='start_tstamp',
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    sort='start_tstamp',
+    dist='session_id',
     partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
     }, databricks_val='start_tstamp_date'),
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["session_id"], snowflake_val=["to_date(start_tstamp)"]),
     full_refresh=snowplow_ecommerce.allow_refresh(),
     tags=["manifest"],
-    snowplow_optimize=true
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    tblproperties={
+      'delta.autoOptimize.optimizeWrite' : 'true',
+      'delta.autoOptimize.autoCompact' : 'true'
+    },
+    snowplow_optimize = true
   )
 }}
 

--- a/models/base/manifest/snowplow_ecommerce_incremental_manifest.sql
+++ b/models/base/manifest/snowplow_ecommerce_incremental_manifest.sql
@@ -2,7 +2,11 @@
   config(
     materialized='incremental',
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
-    full_refresh=snowplow_ecommerce.allow_refresh()
+    full_refresh=snowplow_ecommerce.allow_refresh(),
+    tblproperties={
+      'delta.autoOptimize.optimizeWrite' : 'true',
+      'delta.autoOptimize.autoCompact' : 'true'
+    }
   )
 }}
 


### PR DESCRIPTION
## Description & motivation
This version adds configuration properties to the `snowplow_ecommerce_incremental_manifest` and `snowplow_ecommerce_base_sessions_lifecycle_manifest` that were missing (in particular `sort`, `dist`, `cluster_by`, `tblproperties`).

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)

## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have updated the CHANGELOG.md 
