### PR TITLE
Fix error on Redshift due to base_events_this_run using the transaction_id as partition key event if transactions are disabled (close #51)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+snowplow-ecommerce 0.8.2 (2024-04-05)
+---------------------------------------
+## Summary
+This release fixes a bug on Redshift that caused an error in case transactions were disabled.
+
+## Fixes
+- Fix error on Redshift due to base_events_this_run using the transaction_id as partition key event if transactions are disabled (#51)
+
+## Upgrading
+To upgrade simply bump the snowplow-ecommerce version in your `packages.yml` file.
+
 snowplow-ecommerce 0.8.1 (2024-03-18)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 name: 'snowplow_ecommerce'
 
-version: '0.8.1'
+version: '0.8.2'
 config-version: 2
 
 require-dbt-version: [">=1.5.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_ecommerce_integration_tests'
-version: '0.8.1'
+version: '0.8.2'
 config-version: 2
 
 profile: 'integration_tests'


### PR DESCRIPTION
## Description

Fixes the error in #51 by not using the `transaction_id` in the partition by columns in case transactions are disabled.

## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Related Tickets & Documents
Fixes #51 

## Checklist
- [x] ❗️ I have verified that these changes work on Redshift
- [ ] 💣 Is your change a breaking change?
- [x] 📖 I have updated the CHANGELOG.md

### Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?
- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [x] 🙅 no documentation needed
