### PR TITLE
Allow latest dbt version in pr tests

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Python setup
         uses: actions/setup-python@v4
         with:
-         python-version: "3.8.x"
+         python-version: "3.9.x"
 
       - name: Pip cache
         uses: actions/cache@v3


### PR DESCRIPTION
## Description

Quick fix to bump the python version so that the latest dbt package can run automatically to prevent accidental bugs being introduced by dbt.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
