### PR TITLE
Release/snowplow ecommerce/1.0.1

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -141,14 +141,14 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel setuptools
-          pip install -Iv dbt-${{env.WAREHOUSE_PLATFORM}}==${{ matrix.dbt_version }} --upgrade
+          pip install -Iv dbt-${{env.WAREHOUSE_PLATFORM}}==${{ matrix.dbt_version }} "dbt-core<2.0.0" --upgrade
           dbt deps
         if: ${{env.WAREHOUSE_PLATFORM != 'spark'}}
 
       - name: Install spark dependencies
         run: |
           pip install --upgrade pip wheel setuptools
-          pip install -Iv "dbt-${{ env.WAREHOUSE_PLATFORM }}[PyHive]"==${{ matrix.dbt_version }} --upgrade
+          pip install -Iv "dbt-${{ env.WAREHOUSE_PLATFORM }}[PyHive]"==${{ matrix.dbt_version }} "dbt-core<2.0.0" --upgrade
           dbt deps
         if: ${{env.WAREHOUSE_PLATFORM == 'spark'}}
       
@@ -167,6 +167,7 @@ jobs:
         if: ${{env.WAREHOUSE_PLATFORM == 'spark'}}
     
       - name: "Pre-test: Drop ci schemas"
+        continue-on-error: true
         run: |
           dbt run-operation post_ci_cleanup --target ${{matrix.warehouse}}
 
@@ -174,5 +175,6 @@ jobs:
         run: ./.scripts/integration_test.sh -d ${{matrix.warehouse}}
 
       - name: "Post-test: Drop ci schemas"
+        continue-on-error: true
         run: |
           dbt run-operation post_ci_cleanup --target ${{matrix.warehouse}}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+snowplow-ecommerce 1.0.1 (2026-06-16)
+---------------------------------------
+## Summary
+This patch release restores the `database` field in the events source definition (`models/base/src_base.yml`), which was accidentally commented out in 0.9.0 and remained missing through 1.0.0. Users who had `snowplow__database` set to a different value than `target.database`, or Databricks users relying on `snowplow__databricks_catalog`, would have been querying the wrong database during those releases. In most cases this would have surfaced as an immediate error; the silent failure scenario (wrong data, no error) only applies where both databases are accessible with the same credentials and have the atomic events table with the necessary columns this package expects. Affected users should run `dbt run --full-refresh` after upgrading.
+
+## Upgrading
+To upgrade bump the snowplow-ecommerce version in your `packages.yml` file.
+
 snowplow-ecommerce 1.0.0 (2026-05-06)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 name: 'snowplow_ecommerce'
 
-version: '1.0.0'
+version: '1.0.1'
 config-version: 2
 
 require-dbt-version: [">=1.10.6", "<2.0.0"]

--- a/integration_tests/.gitignore
+++ b/integration_tests/.gitignore
@@ -2,3 +2,4 @@
 target/
 dbt_modules/
 logs/
+dbt_internal_packages/

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_ecommerce_integration_tests'
-version: '1.0.0'
+version: '1.0.1'
 config-version: 2
 
 profile: 'integration_tests'

--- a/models/base/src_base.yml
+++ b/models/base/src_base.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: atomic
     schema: "{{ var('snowplow__atomic_schema', 'atomic') if project_name != 'snowplow_ecommerce_integration_tests' else target.schema~'_snplw_ecommerce_int_tests' }}"
-    # database: "{{ var('snowplow__database', target.database) if target.type not in ['databricks', 'spark'] else var('snowplow__databricks_catalog', 'hive_metastore') if target.type in ['databricks'] else none }}"
+    database: "{{ var('snowplow__database', target.database) if target.type not in ['databricks', 'spark'] else var('snowplow__databricks_catalog', 'hive_metastore') if target.type in ['databricks'] else none }}"
     tables:
       - name: events
         identifier: "{{ var('snowplow__events_table', 'events') if project_name != 'snowplow_ecommerce_integration_tests' else 'snowplow_ecommerce_events_stg' }}"


### PR DESCRIPTION
## Description

This patch release restores the `database` field in the events source definition (`models/base/src_base.yml`), which was accidentally commented out in 0.9.0 and remained missing through 1.0.0. Users who had `snowplow__database` set to a different value than `target.database`, or Databricks users relying on `snowplow__databricks_catalog`, would have been querying the wrong database during those releases. In most cases this would have surfaced as an immediate error; the silent failure scenario (wrong data, no error) only applies where both databases are accessible with the same credentials and have the atomic events table with the necessary columns this package expects. Affected users should run `dbt run --full-refresh` after upgrading.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
-->

## Checklist
- [ ] 💣 Is your change a breaking change?
- [x] 📖 I have updated the CHANGELOG.md

### Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?
- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [x] 🙅 no documentation needed
